### PR TITLE
optimise gitbucket 4.37.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ name := "gitbucket-fess-plugin"
 
 organization := "org.codelibs.gitbucket"
 
-version := "1.7.0"
+version := "1.8.0"
 
 scalaVersion := "2.13.3"
 
-gitbucketVersion := "4.35.0"
+gitbucketVersion := "4.37.2"
 
 publishMavenStyle := true
 

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -22,6 +22,7 @@ class Plugin extends gitbucket.core.plugin.Plugin {
          new Version("1.5.0"),
          new Version("1.6.0"),
          new Version("1.7.0"),
+         new Version("1.8.0"),
     )
   override val controllers = Seq(
     // Note: "/api/v3/" is a special prefix in ControllerBase.scala and Implicits.scala

--- a/src/main/scala/org/codelibs/gitbucket/fess/service/FessSearchService.scala
+++ b/src/main/scala/org/codelibs/gitbucket/fess/service/FessSearchService.scala
@@ -134,7 +134,7 @@ trait FessSearchService {
       val revCommit =
         JGitUtil.getRevCommitFromId(git, git.getRepository.resolve(revStr))
       getPathObjectId(git, path, revCommit).flatMap({ objectId =>
-        JGitUtil.getContentInfo(git, path, objectId).content
+        JGitUtil.getContentInfo(git, path, objectId, false).content
       })
     }
 


### PR DESCRIPTION
Fixed a problem with gitbucket 4.37.2.

Fixed a problem with gitbucket 4.37.2.

Fess version 14.2.0 was used.
At that time, if "{role}guest" was not set to "permissions" in the AccessToken settings of Fess, only private repositories were searched.
This is not an Issue for this plugin, so it will not be submitted.


